### PR TITLE
chore: git ignore the secrets file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,86 @@
+# Manually added entries
+client_secrets.json
+
+# Generated entries
+# Created by https://www.toptal.com/developers/gitignore/api/windows,macos,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=windows,macos,visualstudiocode
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/windows,macos,visualstudiocode

--- a/client_secrets.example.json
+++ b/client_secrets.example.json
@@ -6,8 +6,6 @@
         "token_uri": "https://oauth2.googleapis.com/token",
         "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
         "client_secret": "your_client_secret",
-        "redirect_uris": [
-            "http://localhost"
-        ]
+        "redirect_uris": ["http://localhost"]
     }
 }


### PR DESCRIPTION
The secrets file shows up as a change to be committed, so:
- renamed the example file to `client_secrets.example.json`
- ignored `client_secrets.json`